### PR TITLE
-v flag to list member size and creation time

### DIFF
--- a/README
+++ b/README
@@ -1,0 +1,40 @@
+ddar
+====
+
+ddar is a free de-duplicating archiver for Unix. Save space, bandwidth and time by storing duplicate regions of data only once.
+
+For details, see: [http://www.synctus.com/ddar/][1].
+
+Installation
+------------
+
+Some [pre-built packages][1] are available.
+
+Building from Source
+--------------------
+
+For Debian/Ubuntu packages, just install build dependencies (see
+`debian/control`) and then run `debuild` as usual.
+
+Other distributions: install [protobuf][2], run `make pydist` and then `python
+setup.py install`.
+
+Contributing
+------------
+
+Please submit contributions as pull requests on [github][3], following these
+guidelines:
+
+ * Maintain compatibility with Python 2.5.
+
+ * Keep behaviour similar to `ar(1)` and `tar(1)` (principle of least surprise).
+   Options, behaviour and formats that make sense to match should match as
+   closely as possible.
+
+ * The manpage should be the source of all knowledge. All options and behaviour
+   should be documented there.
+
+
+[1]: http://www.synctus.com/ddar/
+[2]: http://code.google.com/p/protobuf/
+[3]: https://github.com/basak/ddar


### PR DESCRIPTION
Hi,

I've added a _-v_ flag to be used in conjunction with _t_ which will output the member data size in addition to it's creation time. Thought this might be useful.

-Stefhen

Example:

```
$ ./ddar t -v /tmp/ddar
MEMBER                                                           SIZE         CREATED
zips.tar.gz                                                      1182390061   2011-03-17 15:32
ddar.tar.gz                                                      460042       2011-03-23 16:41
dox.tar.gz                                                       44471340     2011-03-23 16:42
test with spaces.tar                                             686080       2011-03-23 17:15
super long archive name goes here to test width formatting.tar   1468         2011-03-23 17:32
```
